### PR TITLE
Add a test to document Prometheus' behaviour with changed label names.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ ci-clean:
 	-make stop-ci-services
 	-rm -rf /tmp/kafka-logs
 	-rm -rf /tmp/zookeeper
+	-rm -rf ../wonko-client
 
 tests: download-lein-libs
 	$(LEIN_ENV) $(LEIN) test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY:	env tests log-dirs ci ci-clean
+.PHONY:	env tests log-dirs ci ci-clean deps
 
 ARCHIVA_USERNAME = $(shell grep access_key ~/.s3cfg | head -n1 | awk -F ' = ' '{print $$2 }')
 ARCHIVA_PASSPHRASE = $(shell grep secret_key ~/.s3cfg | head -n1 | awk -F ' = ' '{print $$2}')
@@ -83,8 +83,5 @@ log-dirs: /var/log/wonko
 checkouts:
 	mkdir checkouts
 
-../wonko-client:
-	git clone git@github.com:StaplesLabs/wonko-client.git ../wonko-client
-
-checkouts/wonko-client: ../wonko-client checkouts
+checkouts/wonko-client: deps checkouts
 	ln -fs ../../wonko-client $@

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ stop-ci-services:
 	-./bin/deps stop kafka
 	-./bin/deps stop zookeeper
 
-ci: force-config-edn log-dirs
+ci: force-config-edn log-dirs checkouts/wonko-client
 	make start-ci-services
 	make tests
 

--- a/src/wonko/export/prometheus.clj
+++ b/src/wonko/export/prometheus.clj
@@ -54,7 +54,8 @@
     (catch Exception e
       (log/info {:msg "unable to register event in prometheus"
                  :event event
-                 :exception (bean e)}))))
+                 :exception (bean e)})
+      (throw e))))
 
 (defn metrics-endpoint [service]
   (let [registry (get-in @created-metrics [service :registry])

--- a/test/wonko/core_test.clj
+++ b/test/wonko/core_test.clj
@@ -91,3 +91,23 @@
                     tu/prometheus-registry->map)))
         (consume/stop thread-pool)
         (tu/delete-topics events-topic alerts-topic)))))
+
+(deftest exceptions-and-validations
+  (testing "I get warned (via exception) if I change label names"
+    (let [service-name "wonko-test-validation-service"
+          {:keys [events-topic alerts-topic]} (tu/create-topics)]
+
+      (tu/init-client service-name events-topic alerts-topic)
+      (client/counter :validation-metric {:first 5})
+      (is (thrown? IllegalArgumentException (client/counter :validation-metric {:first 6 :second 7})))
+
+      (let [consumed-events (atom [])
+            thread-pool (consume/start {events-topic 1 alerts-topic 1}
+                                       (fn [event]
+                                         (process event)
+                                         (swap! consumed-events conj event)))]
+        (tu/wait-for #(= 1 (count @consumed-events)) :interval 1 :timeout 3)
+        (is (= (count @consumed-events) 1))
+
+        (consume/stop thread-pool)
+        (tu/delete-topics events-topic alerts-topic)))))

--- a/test/wonko/core_test.clj
+++ b/test/wonko/core_test.clj
@@ -108,16 +108,16 @@
       (client/stream :validation-metric {:first 5} 5)
       (is (thrown? IllegalArgumentException (client/stream :validation-metric {:first 6 :second 7} 6)))
 
-      (client/alert :validation-metric {:first 5})
-      (is (client/alert :validation-metric {:first 6 :second 7}))
+      (client/alert :some-alert {:first 5})
+      (is (client/alert :some-alert {:first 6 :second 7}))
 
       (let [consumed-events (atom [])
             thread-pool (consume/start {events-topic 1 alerts-topic 1}
                                        (fn [event]
                                          (process event)
                                          (swap! consumed-events conj event)))]
-        (tu/wait-for #(= 4 (count @consumed-events)) :interval 1 :timeout 3)
-        (is (= (count @consumed-events) 4))
+        (tu/wait-for #(= 5 (count @consumed-events)) :interval 1 :timeout 3)
+        (is (= (count @consumed-events) 5))
 
         (consume/stop thread-pool)
         (tu/delete-topics events-topic alerts-topic)))))

--- a/test/wonko/export/prometheus_test.clj
+++ b/test/wonko/export/prometheus_test.clj
@@ -6,6 +6,17 @@
 
 (use-fixtures :each tf/with-cleared-prometheus-state)
 
+(deftest label-names
+  (testing "an exception is thrown when label names are changed for a metric"
+    (let [registry (sut/get-or-create-registry "label-names-test-service")]
+      (sut/register-event {:service "label-names-test-service" :metric-name "metric" :metric-type "counter"
+                           :properties {:foo "bar"}})
+
+      (is (thrown-with-msg?
+           IllegalArgumentException #"Incorrect number of labels"
+           (sut/register-event {:service "label-names-test-service" :metric-name "metric" :metric-type "counter"
+                                :properties {:foo "bar" :baz "quux"}}))))))
+
 (deftest thread-safety
   (testing "get-or-create-registry is thread-safe"
     (let [registries (atom #{})


### PR DESCRIPTION
- Also change the `wonko_client` deps script to checkout a branch in the client (if it exists) with the same name as the parent branch. That should ensure that this branch builds fine in CI. This script is not perfect, but works for now. We're the only ones using it, so we can change it if we need to. ([diff](https://github.com/StaplesLabs/Deps/compare/ce7665cc26cb244acfb19b839d3d5da3883b7ad4...d738ea7381b8e705fda858c8911fe07f023e706c))

**Status: Done**
